### PR TITLE
Add CSV as an output format.

### DIFF
--- a/data/dekalb_scraper.py
+++ b/data/dekalb_scraper.py
@@ -1,3 +1,4 @@
+import argparse
 import datetime
 import requests
 import json
@@ -95,7 +96,7 @@ def take_fields_of_interest(case):
     }
 
 
-def run():
+def run(output_format):
     api = API()
 
     date_from = datetime.date.today()
@@ -112,7 +113,23 @@ def run():
 
     log("Finished.")
 
-    write_csv(results)
+    if output_format == "csv":
+        write_csv(results)
+        return
+    if output_format == "json":
+        write_json(results)
+
+    print(f"Unknown output format: '{output_format}'!")
 
 
-run()
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--output", nargs="?", choices=["json", "csv"], help="Output format"
+)
+
+args = parser.parse_args()
+if args.output is None:
+    parser.print_help()
+    sys.exit(1)
+
+run(args.output)

--- a/data/dekalb_scraper.py
+++ b/data/dekalb_scraper.py
@@ -2,6 +2,7 @@ import datetime
 import requests
 import json
 import sys
+import csv
 from bs4 import BeautifulSoup
 
 
@@ -74,6 +75,17 @@ def log(str):
     print(str, file=sys.stderr)
 
 
+def write_json(results):
+    print(json.dumps(results))
+
+
+def write_csv(results):
+    fieldnames = ["CaseId", "HearingDate", "HearingTime", "CourtRoom"]
+    writer = csv.DictWriter(sys.stdout, fieldnames=fieldnames)
+    writer.writeheader()
+    writer.writerows(results)
+
+
 def take_fields_of_interest(case):
     return {
         "CaseId": case["CaseId"],
@@ -100,7 +112,7 @@ def run():
 
     log("Finished.")
 
-    print(json.dumps(results))
+    write_csv(results)
 
 
 run()


### PR DESCRIPTION
This PR adds CSV output as an option to the scraper. CSV is well suited for importing into a databases.

When running the scraper, specify the output format using the '--output' argument:

`python dekalb_scraper.py --output {json,csv}`

Here is an example that populate the 'cases' table in an sqlite3 database:

`python dekalb_scraper.py --output csv | sqlite3 database.sqlite3 ".import --csv /dev/stdin cases"`