### PR TITLE
Fix missing data issue, #24.

### DIFF
--- a/data/dekalb_scraper.py
+++ b/data/dekalb_scraper.py
@@ -1,4 +1,4 @@
-import argparse
+import click
 import datetime
 import requests
 import json
@@ -140,14 +140,7 @@ def report(results, output_format):
     print(f"Unknown output format: '{output_format}'!")
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument(
-    "--output", nargs="?", choices=["json", "csv"], help="Output format"
-)
-
-args = parser.parse_args()
-if args.output is None:
-    parser.print_help()
-    sys.exit(1)
-
-report(scrape(), output_format=args.output)
+@click.command()
+@click.option("--output", type=click.Choice(["csv", "json"], case_sensitive=False))
+def run(output):
+    report(scrape(), output_format=output)

--- a/data/dekalb_scraper.py
+++ b/data/dekalb_scraper.py
@@ -7,7 +7,7 @@ import csv
 from bs4 import BeautifulSoup
 
 
-class API:
+class Scraper:
     def __init__(self):
         self.headers = {"User-Agent": "CodeForAtlanta Court Bot"}
         self.session = requests.Session()
@@ -105,7 +105,7 @@ def take_fields_of_interest(case):
 
 
 def run(output_format):
-    api = API()
+    scraper = Scraper()
 
     date_from = datetime.date.today()
     date_to = date_from + datetime.timedelta(days=90)
@@ -115,8 +115,8 @@ def run(output_format):
     log("Scraping Dekalb County court cases per judicial officer...")
     log("ID\tName")
 
-    for officer in api.get_all_judicial_officers():
-        cases = api.get_cases_by_judicial_officer(officer, date_from, date_to)
+    for officer in scraper.get_all_judicial_officers():
+        cases = scraper.get_cases_by_judicial_officer(officer, date_from, date_to)
         fields_of_interest = [take_fields_of_interest(case) for case in cases]
         fields_of_interest = [
             fields | {"JudicialOfficer": officer["name"]}

--- a/data/dekalb_scraper.py
+++ b/data/dekalb_scraper.py
@@ -69,7 +69,9 @@ class Scraper:
         log(f'{officer["id"]}\t{officer["name"]}')
         self.submit_search_by_judicial_officer(officer["id"], date_from, date_to)
 
-        return self.get_search_result()["Data"]
+        response = self.get_search_result()
+        print(json.dumps(response, indent=2))
+        return response["Data"]
 
 
 def log(str):
@@ -101,6 +103,7 @@ def take_fields_of_interest(case):
         "HearingDate": case["HearingDate"],
         "HearingTime": case["HearingTime"],
         "CourtRoom": case["CourtRoom"],
+        "JudicialOfficer": case["JudgeParsed"],
     }
 
 
@@ -117,15 +120,7 @@ def scrape():
 
     for officer in scraper.get_all_judicial_officers():
         cases = scraper.get_cases_by_judicial_officer(officer, date_from, date_to)
-        fields_of_interest = [take_fields_of_interest(case) for case in cases]
-        fields_of_interest = [
-            fields | {"JudicialOfficer": officer["name"]}
-            for fields in fields_of_interest
-        ]
-
-        results.extend(fields_of_interest)
-
-    log("Finished.")
+        results.extend([take_fields_of_interest(case) for case in cases])
 
     return results
 
@@ -144,3 +139,6 @@ def report(results, output_format):
 @click.option("--output", type=click.Choice(["csv", "json"], case_sensitive=False))
 def run(output):
     report(scrape(), output_format=output)
+
+
+run()

--- a/data/dekalb_scraper.py
+++ b/data/dekalb_scraper.py
@@ -104,7 +104,7 @@ def take_fields_of_interest(case):
     }
 
 
-def run(output_format):
+def scrape():
     scraper = Scraper()
 
     date_from = datetime.date.today()
@@ -127,6 +127,10 @@ def run(output_format):
 
     log("Finished.")
 
+    return results
+
+
+def report(results, output_format):
     if output_format == "csv":
         write_csv(results)
         return
@@ -146,4 +150,4 @@ if args.output is None:
     parser.print_help()
     sys.exit(1)
 
-run(args.output)
+report(scrape(), output_format=args.output)

--- a/data/dekalb_scraper.py
+++ b/data/dekalb_scraper.py
@@ -105,11 +105,11 @@ def take_fields_of_interest(case):
     }
 
 
-def scrape():
+def scrape(days):
     scraper = Scraper()
 
     date_from = datetime.date.today()
-    date_to = date_from + datetime.timedelta(days=90)
+    date_to = date_from + datetime.timedelta(days)
 
     results = []
 
@@ -153,9 +153,19 @@ def report(results, output_format):
 
 
 @click.command()
-@click.option("--output", type=click.Choice(["csv", "json"], case_sensitive=False))
-def run(output):
-    report(scrape(), output_format=output)
+@click.option(
+    "--output",
+    type=click.Choice(["csv", "json"]),
+    help="Format to use when reporting scraped data.",
+)
+@click.option(
+    "--days",
+    type=int,
+    default=90,
+    help="How many days of data to scrape, measured from today. Default is 90 days.",
+)
+def run(output, days):
+    report(scrape(days=days), output_format=output)
 
 
 run()

--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -1,6 +1,7 @@
 beautifulsoup4==4.10.0
 certifi==2021.10.8
 charset-normalizer==2.0.10
+click==8.0.3
 idna==3.3
 requests==2.27.1
 soupsieve==2.3.1


### PR DESCRIPTION
This PR fixes the issue #24 where data may be missing if the scrape date range is especially large.

The changes are:
- The scraper will now recursively 'page' through cases to circumvent the hard 200 record limit.
- A new CLI argument, `--days` specifying how many days worth of case data to scrape. It is optional, and defaults to 90 days. For example: `python dekalb_scraper.py --days 180 --output json`.
- A new dependency. The scraper now uses the 'click' package for CLI parsing.

