### PR TITLE
Turn off SSL verification as workaround to server misconfiguration, #30.

### DIFF
--- a/scraper/data/dekalb_scraper.py
+++ b/scraper/data/dekalb_scraper.py
@@ -15,7 +15,8 @@ class Scraper:
 
     def get_all_judicial_officers(self):
         url = "https://ody.dekalbcountyga.gov/portal/Home/Dashboard/26"
-        response = self.session.get(url, headers=self.headers)
+        # Ignore SSL verification issues because the remote site returns an incomplete certificate chain.
+        response = self.session.get(url, headers=self.headers, verify=False)
         soup = BeautifulSoup(response.content, "html.parser")
 
         result = [


### PR DESCRIPTION
This PR is a workaround for the SSL configuration of the `https://ody.dekalbcountyga.gov` website. The scraper fails to run because the site returns an incomplete certificate chain. Python's Requests package does not download intermediate certificates and is therefore unable to verify the certificate. With this patch the request is not verified, warnings are printed, and the scrape task continues. 