### PR TITLE
Add cloud run wrapper triggered by a GitHub action

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+Dockerfile
+README.md
+*.pyc
+*.pyo
+*.pyd
+__pycache__
+.pytest_cache

--- a/.github/workflows/deploy_to_gcr.yaml
+++ b/.github/workflows/deploy_to_gcr.yaml
@@ -1,0 +1,113 @@
+# Borrowed from a Google example:
+# https://github.com/google-github-actions/deploy-cloudrun/blob/main/.github/workflows/example-workflow.yaml
+
+# This is a manually activated GitHub action to deploy the scraper to Google CLoud Run
+# and set Cloud Scheduler for it to run at 3am daily
+
+# If the Cloud Service already exists, the image will be overwritten with a new build
+
+# Create a GCP service account with the following permissions:
+# Cloud Run Admin (allows for the creation of new Cloud Run services)
+# Service Account User (required to deploy to Cloud Run as service account)
+# Storage Admin (allow push to Google Container Registry)
+#     Google recommends reducing this scope to bucket level permissions.
+# Cloud Scheduler Admin (to create a scheduler job)
+# BigQuery Data Editor (for the cloud run service to upload data to BigQuery)
+
+# In the Service Account UI, click KEYS, then ADD KEY, then Create new key, then select JSON.
+# Copy the JSON text of the key into a GitHub secret for this repo and name the secret GCP_SA_KEY.
+
+# Note that by default Cloud Run does not allow anonymous runs.  Use the following from Cloud Shell
+# to create an identity token from the local environment:
+# curl <url> -G -H "Authorization: bearer $(gcloud auth print-identity-token)"
+
+name: Build and Deploy to Google Cloud Run
+
+# Manual trigger on github.com
+# This can also be triggered to run on merges, pull requests, etc
+on:
+  workflow_dispatch:
+    inputs:
+      project_id:
+        description: 'Google Cloud project id'
+        required: true
+      dataset_id:
+        description: 'Google BigQuery Dataset id'
+        required: true
+      table_id:
+        description: 'Google BigQuery table id'
+        required: true
+      service:
+        description: 'Cloud Run service name'
+        required: true
+      service_account_email:
+        description: 'Service account email'
+        required: true
+      region:
+        description: 'Cloud Run region'
+        required: true
+        default: 'us-east1'
+
+
+env:
+  PROJECT_ID: ${{ github.event.inputs.project_id }}
+  DATASET_ID: ${{ github.event.inputs.dataset_id }}
+  TABLE_ID: ${{ github.event.inputs.table_id }}
+  SERVICE: ${{ github.event.inputs.service }}
+  REGION: ${{ github.event.inputs.region }}
+  SERVICE_ACCT_EMAIL: ${{ github.event.inputs.service_account_email }}
+
+jobs:
+
+  # should add a linter and unit testing here
+
+  setup-build-push-deploy:
+    name: Setup, Build, Push, and Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Authenticate to Google Cloud
+      uses: 'google-github-actions/auth@v0'
+      with:
+        credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+    - name: Initialize Cloud SDK
+      uses: 'google-github-actions/setup-gcloud@v0.4.0'
+
+    # Configure Docker to use the gcloud command-line tool as a credential
+    # helper for authentication
+    - name: Authorize Docker push
+      run: gcloud auth configure-docker
+      
+    - name: Build and Push Container
+      run: |-
+        docker build -t gcr.io/${{ env.PROJECT_ID }}/${{ env.SERVICE }}:${{  github.sha }} .
+        docker push gcr.io/${{ env.PROJECT_ID }}/${{ env.SERVICE }}:${{  github.sha }}
+
+    # Output of the Cloud Run Deploy action is the url of the deployed service
+    - name: Deploy to Cloud Run
+      id: deploy   # use the id to access the output url: steps.deploy.outputs.url
+      uses: google-github-actions/deploy-cloudrun@v0
+      with:
+        service: '${{ env.SERVICE }}'
+        image: 'gcr.io/${{ env.PROJECT_ID }}/${{ env.SERVICE }}:${{  github.sha }}'
+        region: '${{ env.REGION }}'
+        timeout: '10m'  # 10 minutes
+        env_vars: 'PROJECT_ID=${{ env.PROJECT_ID }},DATASET_ID=${{ env.DATASET_ID }},TABLE_ID=${{ env.TABLE_ID }}'
+
+    # There is no provided github action for Cloud Scheduler so use CLI
+    # The chron is set to run daily at 8am UTC (3am EST)
+    - name: Set Cloud Schedule
+      run: |-
+        gcloud scheduler jobs create http cloud-run-scheduler --schedule "0 8 * * *" \
+          --location '${{ env.REGION }}' \
+          --http-method GET \
+          --uri "${{ steps.deploy.outputs.url }}" \
+          --oidc-service-account-email "${{ env.SERVICE_ACCT_EMAIL }}" \
+          --oidc-token-audience "${{ steps.deploy.outputs.url }}"
+
+    - name: Show Output
+      run: echo ${{ steps.deploy.outputs.url }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Use the official lightweight Python image.
+# https://hub.docker.com/_/python
+FROM python:3.10-slim
+
+# Allow statements and log messages to immediately appear in the Knative logs
+ENV PYTHONUNBUFFERED True
+
+# Copy local code to the container image.
+ENV APP_HOME /app
+WORKDIR $APP_HOME
+COPY requirements.txt ./
+COPY cloudrun/main.py ./
+COPY scraper ./scraper
+
+# Install production dependencies.
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Run the web service on container startup. Here we use the gunicorn
+# webserver, with one worker process and 8 threads.
+# For environments with multiple CPU cores, increase the number of workers
+# to be equal to the cores available.
+# Timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling.
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app

--- a/cloudrun/main.py
+++ b/cloudrun/main.py
@@ -1,0 +1,56 @@
+from google.cloud import bigquery
+from google.api_core.exceptions import NotFound
+import os
+import requests
+from flask import Flask
+import sys
+
+from scraper.data.dekalb_scraper import run
+
+
+app = Flask(__name__)
+
+@app.route("/")
+def run_scrape():
+
+    sys.stdout = open('/tmp/temp.csv','w')
+    run('csv', 90)
+    sys.stdout.close()
+
+    bigquery_client = bigquery.Client()
+
+    table_id = f"{os.environ.get('PROJECT_ID')}.{os.environ.get('DATASET_ID')}.{os.environ.get('TABLE_ID')}"
+
+    try:  
+        previous_rows = bigquery_client.get_table(table_id).num_rows
+    except NotFound:
+        previous_rows = 0
+
+    job_config = bigquery.LoadJobConfig(
+        schema=[
+            bigquery.SchemaField("CaseId", "INTEGER"),
+            bigquery.SchemaField("CaseNumber", "STRING"),
+            bigquery.SchemaField("JudicialOfficer", "STRING"),
+            bigquery.SchemaField("HearingDate", "STRING"),
+            bigquery.SchemaField("HearingTime", "STRING"),
+            bigquery.SchemaField("CourtRoom", "STRING"),
+        ],
+        skip_leading_rows=1,
+        # The source format defaults to CSV, so the line below is optional.
+        source_format=bigquery.SourceFormat.CSV,
+        write_disposition=bigquery.WriteDisposition.WRITE_APPEND,
+        create_disposition=bigquery.CreateDisposition.CREATE_IF_NEEDED
+    )
+
+    with open('/tmp/temp.csv', "rb") as source_file:
+        load_job = bigquery_client.load_table_from_file(source_file, table_id, job_config=job_config)
+
+    load_job.result()  # Waits for the job to complete.
+
+    destination_rows = bigquery_client.get_table(table_id).num_rows
+
+    return f"Loaded {destination_rows-previous_rows} rows."
+
+
+if __name__ == "__main__":
+    app.run(debug=True, host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ cachetools==5.0.0
 certifi==2021.10.8
 charset-normalizer==2.0.12
 click==8.0.3
+flask==2.0.2
 google-api-core==2.5.0
 google-auth==2.6.0
 google-cloud-bigquery==2.32.0
@@ -14,6 +15,7 @@ google-resumable-media==2.2.1
 googleapis-common-protos==1.54.0
 grpcio==1.43.0
 grpcio-status==1.43.0
+gunicorn==20.1.0
 idna==3.3
 jsonschema==4.4.0
 packaging==21.3

--- a/scraper/data/dekalb_scraper.py
+++ b/scraper/data/dekalb_scraper.py
@@ -12,6 +12,8 @@ class Scraper:
     def __init__(self):
         self.headers = {"User-Agent": "CodeForAtlanta Court Bot"}
         self.session = requests.Session()
+        self.session.verify = False
+        requests.packages.urllib3.disable_warnings()
 
     def get_all_judicial_officers(self):
         url = "https://ody.dekalbcountyga.gov/portal/Home/Dashboard/26"


### PR DESCRIPTION
This should run smoothly by triggering the GitHub action manually.  The scraper will be scheduled to run at 3am.

I created a Service Account with the correct permissions (cloudrun-sa@cfa-georgia-courtbot.iam.gserviceaccount.com). Just need to generate a key. In the Service Account UI, click KEYS, then ADD KEY, then Create new key, then select JSON. Copy the JSON text of the key into a GitHub secret for this repo and name the secret GCP_SA_KEY.

I made small revisions to the @abrie scraper code to suppress the SSL warnings.  Reject those and use the improved version he has been working on.